### PR TITLE
feat: add new entry to Last Updates for storage submission support

### DIFF
--- a/data/lastUpdates.ts
+++ b/data/lastUpdates.ts
@@ -11,6 +11,12 @@ export interface LastUpdate {
  */
 export const lastUpdates: LastUpdate[] = [
   {
+    feature: "Storage submission: pasted code and attachments support",
+    suggestedBy: ["@TryOmar"],
+    implementedBy: ["@TryOmar"],
+    date: "17 Nov 2025",
+  },
+  {
     feature: "Contribution Panel / Last-Update Tracker",
     suggestedBy: ["@TryOmar"],
     implementedBy: ["@TryOmar"],


### PR DESCRIPTION
- Introduced a new feature entry for storage submission, highlighting support for pasted code and attachments.
- Suggested and implemented by @TryOmar, dated 17 Nov 2025.